### PR TITLE
Handle unlistening from events synchronously from their handlers

### DIFF
--- a/event.js
+++ b/event.js
@@ -7,10 +7,10 @@ function Event() {
     return { broadcast: broadcast, listen: event }
 
     function broadcast(value) {
-        listenersToBroadcast = listeners.concat();
+        listenersToBroadcast = listeners.slice();
         // don't use indexes, this list can be edited while handlers are running
         while (listenersToBroadcast.length) {
-            listenersToBroadcast.pop()(value)
+            listenersToBroadcast.shift()(value)
         }
     }
 

--- a/event.js
+++ b/event.js
@@ -1,34 +1,36 @@
 module.exports = Event
-
 function Event() {
     var listeners = []
-    var listenersToBroadcast = []
 
     return { broadcast: broadcast, listen: event }
 
     function broadcast(value) {
-        listenersToBroadcast = listeners.slice()
-        // don't use indexes, this list can be edited while handlers are running
-        while (listenersToBroadcast.length) {
-            listenersToBroadcast.shift()(value)
+        var listenersCopy = listeners.slice()
+        for (var i = 0; i < listenersCopy.length; i++) {
+            if (!listenersCopy[i].deleted) {
+                listenersCopy[i].fn(value)
+            }
         }
     }
 
     function event(listener) {
-        listeners.push(listener)
+        listeners.push(new ListItem(listener))
 
         return removeListener
 
         function removeListener() {
-            var index = listeners.indexOf(listener)
-            if (index !== -1) {
-                listeners.splice(index, 1)
-            }
-            // if we're mid-broadcast then remove handlers that have not yet fired
-            index = listenersToBroadcast.indexOf(listener)
-            if (index !== -1) {
-                listenersToBroadcast.splice(index, 1)
+            for (var i = 0; i < listeners.length; i++) {
+                if (listeners[i].fn === listener) {
+                    listeners[i].deleted = true
+                    listeners.splice(i, 1)
+                    break
+                }
             }
         }
     }
+}
+
+function ListItem(fn) {
+    this.fn = fn
+    this.deleted = false
 }

--- a/event.js
+++ b/event.js
@@ -7,7 +7,7 @@ function Event() {
     return { broadcast: broadcast, listen: event }
 
     function broadcast(value) {
-        listenersToBroadcast = listeners.slice();
+        listenersToBroadcast = listeners.slice()
         // don't use indexes, this list can be edited while handlers are running
         while (listenersToBroadcast.length) {
             listenersToBroadcast.shift()(value)

--- a/event.js
+++ b/event.js
@@ -2,12 +2,15 @@ module.exports = Event
 
 function Event() {
     var listeners = []
+    var listenersToBroadcast = []
 
     return { broadcast: broadcast, listen: event }
 
     function broadcast(value) {
-        for (var i = 0; i < listeners.length; i++) {
-            listeners[i](value)
+        listenersToBroadcast = listeners.concat();
+        // don't use indexes, this list can be edited while handlers are running
+        while (listenersToBroadcast.length) {
+            listenersToBroadcast.pop()(value)
         }
     }
 
@@ -20,6 +23,11 @@ function Event() {
             var index = listeners.indexOf(listener)
             if (index !== -1) {
                 listeners.splice(index, 1)
+            }
+            // if we're mid-broadcast then remove handlers that have not yet fired
+            index = listenersToBroadcast.indexOf(listener)
+            if (index !== -1) {
+                listenersToBroadcast.splice(index, 1)
             }
         }
     }

--- a/test/index.js
+++ b/test/index.js
@@ -130,6 +130,19 @@ test("multiple", function (assert) {
     assert.end()
 })
 
+test("unlisten from handler", function (assert) {
+    var event = Event();
+    assert.plan(2);
+
+    var unlisten = event.listen(function () {
+        assert.doesNotThrow(unlisten);
+    });
+    event.listen(function () {
+        assert.pass();
+    });
+
+    event.broadcast(1);
+})
 
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -144,6 +144,20 @@ test("unlisten from handler", function (assert) {
     event.broadcast(1);
 })
 
+test("unlisten another from handler", function (assert) {
+    var event = Event();
+    assert.plan(1);
+
+    event.listen(function () {
+        assert.doesNotThrow(unlisten);
+    });
+    var unlisten = event.listen(function () {
+        assert.fail();
+    });
+
+    event.broadcast(1);
+})
+
 
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -131,31 +131,45 @@ test("multiple", function (assert) {
 })
 
 test("unlisten from handler", function (assert) {
-    var event = Event();
-    assert.plan(2);
+    var event = Event()
+    assert.plan(2)
 
     var unlisten = event.listen(function () {
-        assert.doesNotThrow(unlisten);
-    });
+        assert.doesNotThrow(unlisten)
+    })
     event.listen(function () {
-        assert.pass();
-    });
+        assert.pass()
+    })
 
-    event.broadcast(1);
+    event.broadcast(1)
 })
 
 test("unlisten another from handler", function (assert) {
-    var event = Event();
-    assert.plan(1);
+    var event = Event()
+    assert.plan(1)
 
     event.listen(function () {
-        assert.doesNotThrow(unlisten);
-    });
+        assert.doesNotThrow(unlisten)
+    })
     var unlisten = event.listen(function () {
-        assert.fail();
-    });
+        assert.fail()
+    })
 
-    event.broadcast(1);
+    event.broadcast(1)
+})
+
+test("handlers registered from listeners dont running early", function (assert) {
+    var event = Event()
+    assert.plan(1)
+
+    event.listen(function () {
+        assert.pass()
+        event.listen(function () {
+            assert.fail()
+        })
+    })
+
+    event.broadcast(1)
 })
 
 


### PR DESCRIPTION
This patch allows developers to call the unlisten method synchronously from an event handler and have things work the way one would expect.

Before this, if you unlisten from within that same handler then the final handler in the listener list will not fire.

Check the added test cases for the specific corner cases handled by this patch.